### PR TITLE
feature: register meteorological data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -47,7 +47,7 @@
 			<optional>true</optional>
 		</dependency>
 
-	<!-- Open API 3.0 -->
+		<!-- Open API 3.0 -->
 
 		<dependency>
 			<groupId>org.springdoc</groupId>
@@ -59,13 +59,13 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
-<!--			<version>${spring.version}</version>-->
+			<!--			<version>${spring.version}</version>-->
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
-<!--			<version>${spring-security.version}</version>-->
+			<!--			<version>${spring-security.version}</version>-->
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -81,7 +81,7 @@
 			</exclusions>
 		</dependency>
 
-	<!-- Banco de dados -->
+		<!-- Banco de dados -->
 		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
@@ -111,34 +111,35 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.flywaydb</groupId>
+				<artifactId>flyway-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>migrate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<driver>org.postgresql.Driver</driver>
+					<url>jdbc:postgresql://localhost:5432/test</url>
+					<user>postgres</user>
+					<password>root</password>
+					<baselineOnMigrate>true</baselineOnMigrate>
+					<schemas>public</schemas>
+					<locations>
+						<location>
+							filesystem:src/main/resources/db/migration
+						</location>
+					</locations>
+				</configuration>
+			</plugin>
 		</plugins>
 
-<!--		 Auto migration desabilitada por padrão-->
-<!--		<plugin>-->
-<!--			<groupId>org.flywaydb</groupId>-->
-<!--			<artifactId>flyway-maven-plugin</artifactId>-->
-<!--			<executions>-->
-<!--				<execution>-->
-<!--					<phase>generate-sources</phase>-->
-<!--					<goals>-->
-<!--						<goal>migrate</goal>-->
-<!--					</goals>-->
-<!--				</execution>-->
-<!--			</executions>-->
-<!--			<configuration>-->
-<!--				<driver>org.postgresql.Driver</driver>-->
-<!--				<url>jdbc:postgresql://localhost:5432/test</url>-->
-<!--				<user>postgres</user>-->
-<!--				<password>root</password>-->
-<!--				<baselineOnMigrate>true</baselineOnMigrate>-->
-<!--				<schemas>public</schemas>-->
-<!--				<locations>-->
-<!--					<location>-->
-<!--						filesystem:src/main/resources/db/migration-->
-<!--					</location>-->
-<!--				</locations>-->
-<!--			</configuration>-->
-<!--		</plugin>-->
+		<!--        Auto migration desabilitada por padrão-->
+
 		<finalName>template</finalName>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,12 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+
 	<!-- Open API 3.0 -->
 
 		<dependency>

--- a/src/main/java/com/template/Application.java
+++ b/src/main/java/com/template/Application.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class TemplateApplication {
+public class Application {
 
 	public static void main(String[] args) {
-		SpringApplication.run(TemplateApplication.class, args);
+		SpringApplication.run(Application.class, args);
 	}
 
 }

--- a/src/main/java/com/template/business/services/MeteorologicalDataService.java
+++ b/src/main/java/com/template/business/services/MeteorologicalDataService.java
@@ -1,0 +1,29 @@
+package com.template.business.services;
+
+import com.template.data.entity.MeteorologicalDataEntity;
+import com.template.data.repository.MeteorologicalDataRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Service
+public class MeteorologicalDataService {
+
+    @Autowired
+    MeteorologicalDataRepository meteorologicalDataRepository;
+
+    public MeteorologicalDataEntity create(@RequestBody MeteorologicalDataEntity meteorologicalData) {
+
+        return meteorologicalDataRepository.save(new MeteorologicalDataEntity(meteorologicalData.getCity(),
+                meteorologicalData.getWeatherDate(),
+                meteorologicalData.getMorningWeather(),
+                meteorologicalData.getNightWeather(),
+                meteorologicalData.getMaxTemperature(),
+                meteorologicalData.getMinTemperature(),
+                meteorologicalData.getHumidity(),
+                meteorologicalData.getPrecipitation(),
+                meteorologicalData.getWindSpeed()));
+    }
+
+
+}

--- a/src/main/java/com/template/business/services/MeteorologicalDataService.java
+++ b/src/main/java/com/template/business/services/MeteorologicalDataService.java
@@ -13,7 +13,6 @@ public class MeteorologicalDataService {
     MeteorologicalDataRepository meteorologicalDataRepository;
 
     public MeteorologicalDataEntity create(@RequestBody MeteorologicalDataEntity meteorologicalData) {
-
         return meteorologicalDataRepository.save(new MeteorologicalDataEntity(meteorologicalData.getCity(),
                 meteorologicalData.getWeatherDate(),
                 meteorologicalData.getMorningWeather(),
@@ -24,6 +23,4 @@ public class MeteorologicalDataService {
                 meteorologicalData.getPrecipitation(),
                 meteorologicalData.getWindSpeed()));
     }
-
-
 }

--- a/src/main/java/com/template/business/services/MeteorologicalDataService.java
+++ b/src/main/java/com/template/business/services/MeteorologicalDataService.java
@@ -1,6 +1,8 @@
 package com.template.business.services;
 
+import com.template.data.dto.MeteorologicalDataDTO;
 import com.template.data.entity.MeteorologicalDataEntity;
+import com.template.data.enums.WeatherEnum;
 import com.template.data.repository.MeteorologicalDataRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -12,15 +14,15 @@ public class MeteorologicalDataService {
     @Autowired
     MeteorologicalDataRepository meteorologicalDataRepository;
 
-    public MeteorologicalDataEntity create(@RequestBody MeteorologicalDataEntity meteorologicalData) {
-        return meteorologicalDataRepository.save(new MeteorologicalDataEntity(meteorologicalData.getCity(),
-                meteorologicalData.getWeatherDate(),
-                meteorologicalData.getMorningWeather(),
-                meteorologicalData.getNightWeather(),
-                meteorologicalData.getMaxTemperature(),
-                meteorologicalData.getMinTemperature(),
-                meteorologicalData.getHumidity(),
-                meteorologicalData.getPrecipitation(),
-                meteorologicalData.getWindSpeed()));
+    public MeteorologicalDataEntity create(@RequestBody MeteorologicalDataDTO meteorologicalData) {
+        return meteorologicalDataRepository.save(new MeteorologicalDataEntity(meteorologicalData.city(),
+                meteorologicalData.weatherDate(),
+                meteorologicalData.morningWeather(),
+                meteorologicalData.nightWeather(),
+                meteorologicalData.maxTemperature(),
+                meteorologicalData.minTemperature(),
+                meteorologicalData.humidity(),
+                meteorologicalData.precipitation(),
+                meteorologicalData.windSpeed()));
     }
 }

--- a/src/main/java/com/template/data/dto/MeteorologicalDataDTO.java
+++ b/src/main/java/com/template/data/dto/MeteorologicalDataDTO.java
@@ -1,0 +1,19 @@
+package com.template.data.dto;
+
+import com.template.data.enums.WeatherEnum;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record MeteorologicalDataDTO(String city,
+                                    LocalDate weatherDate,
+                                    WeatherEnum morningWeather,
+                                    WeatherEnum nightWeather,
+                                    int maxTemperature,
+                                    int minTemperature,
+                                    int humidity,
+                                    int precipitation,
+                                    int windSpeed
+) {
+}

--- a/src/main/java/com/template/data/dto/MeteorologicalDataDTO.java
+++ b/src/main/java/com/template/data/dto/MeteorologicalDataDTO.java
@@ -1,19 +1,17 @@
 package com.template.data.dto;
 
 import com.template.data.enums.WeatherEnum;
-import lombok.Builder;
 
 import java.time.LocalDate;
 
-@Builder
 public record MeteorologicalDataDTO(String city,
                                     LocalDate weatherDate,
                                     WeatherEnum morningWeather,
                                     WeatherEnum nightWeather,
-                                    int maxTemperature,
-                                    int minTemperature,
-                                    int humidity,
-                                    int precipitation,
-                                    int windSpeed
+                                    Integer maxTemperature,
+                                    Integer minTemperature,
+                                    Integer humidity,
+                                    Integer precipitation,
+                                    Integer windSpeed
 ) {
 }

--- a/src/main/java/com/template/data/entity/MeteorologicalDataEntity.java
+++ b/src/main/java/com/template/data/entity/MeteorologicalDataEntity.java
@@ -1,0 +1,60 @@
+package com.template.data.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@Table(name = "meteorological_data")
+public class MeteorologicalDataEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;
+
+    @Column(name = "city")
+    private String city;
+
+    @Column(name = "weather_date")
+    private LocalDate weatherDate;
+
+    //    @Enumerated(EnumType.STRING)
+    @Column(name = "morning_weather")
+    private String morningWeather;
+
+    //    @Enumerated(EnumType.STRING)
+    @Column(name = "night_weather")
+    private String nightWeather;
+
+    @Column(name = "max_temperature")
+    private int maxTemperature;
+
+    @Column(name = "min_temperature")
+    private int minTemperature;
+
+    @Column(name = "humidity")
+    private int humidity;
+
+    @Column(name = "precipitation")
+    private int precipitation;
+
+    @Column(name = "wind_speed")
+    private int windSpeed;
+
+    public MeteorologicalDataEntity(String city, LocalDate weatherDate, String morningWeather, String nightWeather,
+                                    int maxTemperature, int minTemperature, int humidity, int precipitation, int windSpeed) {
+        this.city = city;
+        this.weatherDate = weatherDate;
+        this.morningWeather = morningWeather;
+        this.nightWeather = nightWeather;
+        this.maxTemperature = maxTemperature;
+        this.minTemperature = minTemperature;
+        this.humidity = humidity;
+        this.precipitation = precipitation;
+        this.windSpeed = windSpeed;
+    }
+
+
+}

--- a/src/main/java/com/template/data/entity/MeteorologicalDataEntity.java
+++ b/src/main/java/com/template/data/entity/MeteorologicalDataEntity.java
@@ -2,13 +2,17 @@ package com.template.data.entity;
 
 import com.template.data.enums.WeatherEnum;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
-@AllArgsConstructor
 @Entity
 @Table(name = "meteorological_data")
 public class MeteorologicalDataEntity {
@@ -17,6 +21,7 @@ public class MeteorologicalDataEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private long id;
 
+    @NotBlank
     @Column(name = "city")
     private String city;
 
@@ -32,19 +37,19 @@ public class MeteorologicalDataEntity {
     private WeatherEnum nightWeather;
 
     @Column(name = "max_temperature")
-    private int maxTemperature;
+    private Integer maxTemperature;
 
     @Column(name = "min_temperature")
     private int minTemperature;
 
     @Column(name = "humidity")
-    private int humidity;
+    private Integer humidity;
 
     @Column(name = "precipitation")
-    private int precipitation;
+    private Integer precipitation;
 
     @Column(name = "wind_speed")
-    private int windSpeed;
+    private Integer windSpeed;
 
     public MeteorologicalDataEntity(String city, LocalDate weatherDate, WeatherEnum morningWeather, WeatherEnum nightWeather,
                                     int maxTemperature, int minTemperature, int humidity, int precipitation, int windSpeed) {

--- a/src/main/java/com/template/data/entity/MeteorologicalDataEntity.java
+++ b/src/main/java/com/template/data/entity/MeteorologicalDataEntity.java
@@ -2,11 +2,13 @@ package com.template.data.entity;
 
 import com.template.data.enums.WeatherEnum;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
 
 @Getter
+@AllArgsConstructor
 @Entity
 @Table(name = "meteorological_data")
 public class MeteorologicalDataEntity {
@@ -56,6 +58,5 @@ public class MeteorologicalDataEntity {
         this.precipitation = precipitation;
         this.windSpeed = windSpeed;
     }
-
 
 }

--- a/src/main/java/com/template/data/entity/MeteorologicalDataEntity.java
+++ b/src/main/java/com/template/data/entity/MeteorologicalDataEntity.java
@@ -1,5 +1,6 @@
 package com.template.data.entity;
 
+import com.template.data.enums.WeatherEnum;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -20,13 +21,13 @@ public class MeteorologicalDataEntity {
     @Column(name = "weather_date")
     private LocalDate weatherDate;
 
-    //    @Enumerated(EnumType.STRING)
+    @Enumerated(EnumType.STRING)
     @Column(name = "morning_weather")
-    private String morningWeather;
+    private WeatherEnum morningWeather;
 
-    //    @Enumerated(EnumType.STRING)
+    @Enumerated(EnumType.STRING)
     @Column(name = "night_weather")
-    private String nightWeather;
+    private WeatherEnum nightWeather;
 
     @Column(name = "max_temperature")
     private int maxTemperature;
@@ -43,7 +44,7 @@ public class MeteorologicalDataEntity {
     @Column(name = "wind_speed")
     private int windSpeed;
 
-    public MeteorologicalDataEntity(String city, LocalDate weatherDate, String morningWeather, String nightWeather,
+    public MeteorologicalDataEntity(String city, LocalDate weatherDate, WeatherEnum morningWeather, WeatherEnum nightWeather,
                                     int maxTemperature, int minTemperature, int humidity, int precipitation, int windSpeed) {
         this.city = city;
         this.weatherDate = weatherDate;

--- a/src/main/java/com/template/data/enums/WeatherEnum.java
+++ b/src/main/java/com/template/data/enums/WeatherEnum.java
@@ -1,0 +1,15 @@
+package com.template.data.enums;
+
+public enum WeatherEnum {
+    RAIN("Chuva"),
+    STORM("Tempestade"),
+    SUN_WITH_CLOUDS("Sol com nuvens"),
+    SUN("Sol"),
+    CLOUDY("Nublado");
+
+    private final String description;
+
+    WeatherEnum(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/template/data/repository/MeteorologicalDataRepository.java
+++ b/src/main/java/com/template/data/repository/MeteorologicalDataRepository.java
@@ -1,0 +1,7 @@
+package com.template.data.repository;
+
+import com.template.data.entity.MeteorologicalDataEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeteorologicalDataRepository extends JpaRepository<MeteorologicalDataEntity, Long> {
+}

--- a/src/main/java/com/template/presentation/controller/MeteorologicalDataController.java
+++ b/src/main/java/com/template/presentation/controller/MeteorologicalDataController.java
@@ -1,0 +1,35 @@
+package com.template.presentation.controller;
+
+import com.template.business.services.MeteorologicalDataService;
+import com.template.data.entity.MeteorologicalDataEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@CrossOrigin(origins = "http://localhost:4767")
+@RestController
+@RequestMapping("/meteorologicalData")
+public class MeteorologicalDataController {
+
+    @Autowired
+    MeteorologicalDataService meteorologicalDataService;
+
+    @PostMapping
+    public ResponseEntity<MeteorologicalDataEntity> createMeteorologicalData(@RequestBody MeteorologicalDataEntity meteorologicalData) {
+        try {
+            MeteorologicalDataEntity _meteorologicalData = meteorologicalDataService.create(new MeteorologicalDataEntity(meteorologicalData.getCity(),
+                    meteorologicalData.getWeatherDate(),
+                    meteorologicalData.getMorningWeather(),
+                    meteorologicalData.getNightWeather(),
+                    meteorologicalData.getMaxTemperature(),
+                    meteorologicalData.getMinTemperature(),
+                    meteorologicalData.getHumidity(),
+                    meteorologicalData.getPrecipitation(),
+                    meteorologicalData.getWindSpeed()));
+            return new ResponseEntity<>(_meteorologicalData, HttpStatus.CREATED);
+        } catch (Exception e) {
+            return new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/template/presentation/controller/MeteorologicalDataController.java
+++ b/src/main/java/com/template/presentation/controller/MeteorologicalDataController.java
@@ -2,6 +2,7 @@ package com.template.presentation.controller;
 
 import com.template.business.services.MeteorologicalDataService;
 import com.template.data.entity.MeteorologicalDataEntity;
+import com.template.data.enums.WeatherEnum;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ public class MeteorologicalDataController {
 
     @PostMapping
     public ResponseEntity<MeteorologicalDataEntity> createMeteorologicalData(@RequestBody MeteorologicalDataEntity meteorologicalData) {
+        
         try {
             MeteorologicalDataEntity _meteorologicalData = meteorologicalDataService.create(new MeteorologicalDataEntity(meteorologicalData.getCity(),
                     meteorologicalData.getWeatherDate(),

--- a/src/main/java/com/template/presentation/controller/MeteorologicalDataController.java
+++ b/src/main/java/com/template/presentation/controller/MeteorologicalDataController.java
@@ -1,8 +1,8 @@
 package com.template.presentation.controller;
 
 import com.template.business.services.MeteorologicalDataService;
+import com.template.data.dto.MeteorologicalDataDTO;
 import com.template.data.entity.MeteorologicalDataEntity;
-import com.template.data.enums.WeatherEnum;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,19 +17,10 @@ public class MeteorologicalDataController {
     MeteorologicalDataService meteorologicalDataService;
 
     @PostMapping
-    public ResponseEntity<MeteorologicalDataEntity> createMeteorologicalData(@RequestBody MeteorologicalDataEntity meteorologicalData) {
-        
+    public ResponseEntity<MeteorologicalDataEntity> createMeteorologicalData(@RequestBody MeteorologicalDataDTO meteorologicalDataDTO) {
         try {
-            MeteorologicalDataEntity _meteorologicalData = meteorologicalDataService.create(new MeteorologicalDataEntity(meteorologicalData.getCity(),
-                    meteorologicalData.getWeatherDate(),
-                    meteorologicalData.getMorningWeather(),
-                    meteorologicalData.getNightWeather(),
-                    meteorologicalData.getMaxTemperature(),
-                    meteorologicalData.getMinTemperature(),
-                    meteorologicalData.getHumidity(),
-                    meteorologicalData.getPrecipitation(),
-                    meteorologicalData.getWindSpeed()));
-            return new ResponseEntity<>(_meteorologicalData, HttpStatus.CREATED);
+            MeteorologicalDataEntity _meteorologicalData = meteorologicalDataService.create(meteorologicalDataDTO);
+            return new ResponseEntity<MeteorologicalDataEntity>(_meteorologicalData, HttpStatus.CREATED);
         } catch (Exception e) {
             return new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/resources/db/migration/V1__create_meteorological_data_table.sql
+++ b/src/main/resources/db/migration/V1__create_meteorological_data_table.sql
@@ -4,10 +4,10 @@ CREATE TABLE IF NOT EXISTS meteorological_data (
   weather_date DATE NOT NULL,
   morning_weather VARCHAR(20) NOT NULL,
   night_weather VARCHAR(20) NOT NULL,
-  max_temperature INT NOT NULL,
-  min_temperature INT NOT NULL,
-  humidity INT NOT NULL,
-  precipitation INT NOT NULL,
-  windSpeed INT NOT NULL,
+  max_temperature INTEGER NOT NULL,
+  min_temperature INTEGER NOT NULL,
+  humidity INTEGER NOT NULL,
+  precipitation INTEGER NOT NULL,
+  wind_speed INTEGER NOT NULL,
   PRIMARY KEY (id)
 );

--- a/src/main/resources/db/migration/V1__create_tutorial_table.sql
+++ b/src/main/resources/db/migration/V1__create_tutorial_table.sql
@@ -1,8 +1,0 @@
---create table IF NOT EXISTS tutorials (
---    id bigint not null,
---    description varchar(255),
---    published boolean,
---    title varchar(255), primary key (id)
---);
---
---create sequence tutorials_seq start with 1 increment by 50

--- a/src/main/resources/db/migration/V2_create_meteorological_data_table.sql
+++ b/src/main/resources/db/migration/V2_create_meteorological_data_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS meteorological_data (
+  id BIGSERIAL NOT NULL,
+  city VARCHAR(45) NOT NULL,
+  weather_date DATE NOT NULL,
+  morning_weather VARCHAR(20) NOT NULL,
+  night_weather VARCHAR(20) NOT NULL,
+  max_temperature INT NOT NULL,
+  min_temperature INT NOT NULL,
+  humidity INT NOT NULL,
+  precipitation INT NOT NULL,
+  windSpeed INT NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/src/test/java/com/template/services/MeteorologicalDataTests.java
+++ b/src/test/java/com/template/services/MeteorologicalDataTests.java
@@ -1,0 +1,74 @@
+package com.template.services;
+
+import com.template.business.services.MeteorologicalDataService;
+import com.template.data.dto.MeteorologicalDataDTO;
+import com.template.data.entity.MeteorologicalDataEntity;
+import com.template.data.enums.WeatherEnum;
+import com.template.data.repository.MeteorologicalDataRepository;
+import com.template.presentation.controller.MeteorologicalDataController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MeteorologicalData Service Tests")
+public class MeteorologicalDataTests {
+
+    @Mock
+    MeteorologicalDataRepository meteorologicalDataRepository;
+
+    @InjectMocks
+    private MeteorologicalDataService meteorologicalDataService;
+
+
+    MeteorologicalDataEntity meteorologicalData = MeteorologicalDataEntity.builder()
+            .id(5)
+            .city("Porto Alegre")
+            .weatherDate(LocalDate.of(2023, 4, 12))
+            .maxTemperature(32)
+            .minTemperature(19)
+            .morningWeather(WeatherEnum.SUN)
+            .nightWeather(WeatherEnum.CLOUDY)
+            .humidity(12)
+            .precipitation(10)
+            .windSpeed(11)
+            .build();
+
+    MeteorologicalDataEntity meteorologicalDataSemID = MeteorologicalDataEntity.builder()
+            .city("Porto Alegre")
+            .weatherDate(LocalDate.of(2023, 4, 12))
+            .maxTemperature(32)
+            .minTemperature(19)
+            .morningWeather(WeatherEnum.SUN)
+            .nightWeather(WeatherEnum.CLOUDY)
+            .humidity(12)
+            .precipitation(10)
+            .windSpeed(11)
+            .build();
+
+    MeteorologicalDataDTO meteorologicalDataDTO = new MeteorologicalDataDTO("Porto Alegre",
+            LocalDate.of(2023, 4, 12),
+            WeatherEnum.SUN, WeatherEnum.CLOUDY, 32, 19, 12, 10, 11);
+
+    @Test
+    @DisplayName("POST - Success")
+    void createSucess() {
+        MeteorologicalDataEntity newMeteorologicalData = meteorologicalDataService.create(meteorologicalDataDTO);
+        assertNotNull(newMeteorologicalData);
+        System.out.println(meteorologicalDataDTO.city());
+        System.out.println("DATA: " + newMeteorologicalData);
+    }
+}

--- a/src/test/java/com/template/services/MeteorologicalDataTests.java
+++ b/src/test/java/com/template/services/MeteorologicalDataTests.java
@@ -5,7 +5,6 @@ import com.template.data.dto.MeteorologicalDataDTO;
 import com.template.data.entity.MeteorologicalDataEntity;
 import com.template.data.enums.WeatherEnum;
 import com.template.data.repository.MeteorologicalDataRepository;
-import com.template.presentation.controller.MeteorologicalDataController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,11 +14,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
-import java.util.Optional;
-import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
@@ -33,42 +32,39 @@ public class MeteorologicalDataTests {
     @InjectMocks
     private MeteorologicalDataService meteorologicalDataService;
 
-
-    MeteorologicalDataEntity meteorologicalData = MeteorologicalDataEntity.builder()
-            .id(5)
-            .city("Porto Alegre")
-            .weatherDate(LocalDate.of(2023, 4, 12))
-            .maxTemperature(32)
-            .minTemperature(19)
-            .morningWeather(WeatherEnum.SUN)
-            .nightWeather(WeatherEnum.CLOUDY)
-            .humidity(12)
-            .precipitation(10)
-            .windSpeed(11)
-            .build();
-
-    MeteorologicalDataEntity meteorologicalDataSemID = MeteorologicalDataEntity.builder()
-            .city("Porto Alegre")
-            .weatherDate(LocalDate.of(2023, 4, 12))
-            .maxTemperature(32)
-            .minTemperature(19)
-            .morningWeather(WeatherEnum.SUN)
-            .nightWeather(WeatherEnum.CLOUDY)
-            .humidity(12)
-            .precipitation(10)
-            .windSpeed(11)
-            .build();
-
     MeteorologicalDataDTO meteorologicalDataDTO = new MeteorologicalDataDTO("Porto Alegre",
+            LocalDate.of(2023, 4, 12),
+            WeatherEnum.SUN, WeatherEnum.CLOUDY, 32, 19, 12, 10, 11);
+
+    MeteorologicalDataEntity meteorologicalData = new MeteorologicalDataEntity("Porto Alegre",
+            LocalDate.of(2023, 4, 12),
+            WeatherEnum.SUN, WeatherEnum.CLOUDY, 32, 19, 12, 10, 11);
+
+    MeteorologicalDataDTO meteorologicalDataDTOInvalid = new MeteorologicalDataDTO(null,
+            LocalDate.of(2023, 4, 12),
+            WeatherEnum.SUN, WeatherEnum.CLOUDY, 32, 19, 12, 10, 11);
+
+    MeteorologicalDataEntity meteorologicalDataInvalid = new MeteorologicalDataEntity(null,
             LocalDate.of(2023, 4, 12),
             WeatherEnum.SUN, WeatherEnum.CLOUDY, 32, 19, 12, 10, 11);
 
     @Test
     @DisplayName("POST - Success")
     void createSucess() {
+        when(meteorologicalDataRepository.save(any())).thenReturn(meteorologicalData);
+
         MeteorologicalDataEntity newMeteorologicalData = meteorologicalDataService.create(meteorologicalDataDTO);
         assertNotNull(newMeteorologicalData);
-        System.out.println(meteorologicalDataDTO.city());
-        System.out.println("DATA: " + newMeteorologicalData);
+        verify(meteorologicalDataRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("POST - Error")
+    void createError() {
+        when(meteorologicalDataRepository.save(any())).thenReturn(meteorologicalDataInvalid);
+
+        MeteorologicalDataEntity newMeteorologicalData = meteorologicalDataService.create(meteorologicalDataDTOInvalid);
+        assertNull(newMeteorologicalData.getCity());
+        verify(meteorologicalDataRepository).save(any());
     }
 }


### PR DESCRIPTION
# Descrição

### **1 - Qual o objetivo desse pull request?**
O objetivo do pull request é que seja possível cadastrar os dados meteorológicos através do backend.

### **2 - Quais alterações foram feitas para atingir esse objetivo?**
Foram criadas as classes Controller, Service, Entity, DTO e Repository para os Dados Meteorológicos. Também foram realizados os testes de erro e sucesso da Service. 

### **3 - Como testar se essas mudanças realmente funcionam?**
No insomnia, basta fazer uma requisição para o endpoint `POST http://localhost:4767/meteorologicalData`, com o seguinte body json: 
```
{
	"city": "Charqueadas",
	"weatherDate": "2023-04-11",
	"morningWeather": "SUN",
	"nightWeather": "RAIN",
	"maxTemperature": 32,
	"minTemperature": 19,
	"humidity": 1,
	"precipitation": 1,
	"windSpeed": 1
}
```
Nesse caso, o retorno deve ser `201 Created`. Caso seja passado algum campo nulo ou que não faça parte do Enum nos campos morningWeather e nightWeather, o cadastro não deve ocorrer. 

### **4 - Possíveis melhorias e outras anotações**
Futuramente pode ser ajustado para que o código retorne erro 400 ao receber algum campo nulo. Também seria importante impedir que o usuário cadastre dois valores diferentes para a mesma cidade no mesmo dia.

### **5 - Numero da issue**

<!-- ex: [ISSUE-123](https://github.com/my-repository/issues/123) -->

[ISSUE #4](https://github.com/WeatherRoJo/dbcamp-template-api/issues/4)

# Checklist

**Se tiver alguma dúvida referente a qualquer item, não hesite em perguntar para o time ou a equipe de engenharia.**

- [x] Realizei o teste local, e minhas alterações funcionam como esperado
- [x] Apliquei as regras do nosso guia de estilo
- [x] Os meus commits estão seguindo nosso modelo de mensagem de commits
